### PR TITLE
Moving Temple-OS to Software instead of Distros

### DIFF
--- a/distributions.html
+++ b/distributions.html
@@ -150,9 +150,6 @@
               <a href="#slitaz">SliTaz Linux</a>
             </li>
             <li>
-              <a href="#templeos">Temple OS</a>
-            </li>
-            <li>
               <a href="#ubuntu">Ubuntu</a>
             </li>
             <li>
@@ -499,15 +496,6 @@ deb-src http://mirror.clarkson.edu/debian-security stretch/updates main
             <br>
             <h5>Homepage:</h5>
             <a href="http://www.slitaz.org/en/">http://www.slitaz.org/en/</a>
-          </div>
-          <div class="distro" id="templeos">
-            <h3>TempleOS</h3>
-            <h5>HTTP:</h5>
-            <a href="./templeos/">http://mirror.clarkson.edu/templeos/</a>
-            <br>
-            <br>
-            <h5>Homepage:</h5>
-            <a href="http://templeos.org/">http://templeos.org/</a>
           </div>
           <div class="distro" id="ubuntu">
             <h3>Ubuntu (Official Mirror)</h3>

--- a/software.html
+++ b/software.html
@@ -135,6 +135,8 @@
               <a href="#tdf">LibreOffice</a>
             </li>
             <li>
+              <a hred="#temple-os">Temple-OS</a>
+            <li>
               <a href="#vlc">VLC</a>
             </li>
           </ul>
@@ -313,6 +315,15 @@
             <br>
             <h5>Homepage:</h5>
             <a href="http://www.documentfoundation.org/">http://www.documentfoundation.org/</a>
+          </section>
+          <section id="templeos">
+            <h3>TempleOS</h3>
+            <h5>HTTP:</h5>
+            <a href="./templeos/">http://mirror.clarkson.edu/templeos/</a>
+            <br>
+            <br>
+            <h5>Homepage:</h5>
+            <a href="http://templeos.org/">http://templeos.org/</a>
           </section>
           <section id="vlc">
             <h3>VLC (Offical Mirror)</h3>


### PR DESCRIPTION
Temple-OS comes from MS-DOS not Unix so it should be moved to be with MS-DOS